### PR TITLE
Fix conditional in deploy_rhel_ai

### DIFF
--- a/nested-passthrough/Makefile
+++ b/nested-passthrough/Makefile
@@ -126,12 +126,12 @@ endif
 deploy_rhel_ai: ## Deploy RHEL AI on RHOSO
 	$(eval $(call vars))
 ifeq (,$(wildcard out/rhel-ai-disk.qcow2))
-	ifeq $($(AI_IMAGE_URL),)
+        ifeq ($(AI_IMAGE_URL),)
 		$(error Please go to https://access.redhat.com/downloads/content/932 , copy the link to the qcow2 download, and pass it in the AI_IMAGE_URL env var or manually download it to out/rhel-ai-disk.qcow2)
-	else
+        else
 		$(info Downloading RHEL AI image)
 		@curl -Lo out/rhel-ai-disk.qcow2 "$(AI_IMAGE_URL)"
-	endif
+        endif
 else
 	$(info RHEL AI image already present in the system)
 endif


### PR DESCRIPTION
@umago noted a problem with this target (on OSPRH-11029) and I was able to reproduce. I found a spurious `$` and invalid spacing.

"Extra spaces are allowed and ignored at the beginning of the conditional directive line, but a tab is not allowed." [1]

I believe this is working properly now:

```
$ make deploy_rhel_ai
Makefile:128: *** Please go to https://access.redhat.com/downloads/content/932 , copy the link to the qcow2 download, and pass it in the AI_IMAGE_URL env var or manually download it to out/rhel-ai-disk.qcow2.  Stop.

$ AI_IMAGE_URL=bogus make deploy_rhel_ai
Downloading RHEL AI image
Deploying RHEL AI on RHOSO
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: bogus
make: *** [Makefile:129: deploy_rhel_ai] Error 6
```

[1] https://www.gnu.org/software/make/manual/html_node/Conditional-Syntax.html