### PR TITLE
Check the "active" status for RHEL AI image

### DIFF
--- a/nested-passthrough/scripts/edpm-deploy-rhel-ai.sh
+++ b/nested-passthrough/scripts/edpm-deploy-rhel-ai.sh
@@ -81,7 +81,7 @@ openstack server show ${VM_NAME} || {
         while [[ "$(openstack image show -c status -f value ${IMAGE_NAME})" == "importing" ]]; do
             sleep 1
         done
-        if "$(openstack image show -c status -f value ${IMAGE_NAME})" != "available"; then
+        if "$(openstack image show -c status -f value ${IMAGE_NAME})" != "active"; then
             print "Error importing image ${IMAGE_NAME}"
             exit 1
         fi


### PR DESCRIPTION
The edpm-deploy-rhel-ai.sh script was showing the error below:

++ openstack image show -c status -f value rhel-ai
+ active '!=' available /tmp/edpm-deploy-rhel-ai.sh: line 84: active: command not found

Turns out the image status is "active" and not "available".

$ openstack image show -c status -f value rhel-ai
active

More: https://docs.openstack.org/glance/latest/user/statuses.html