### PR TITLE
Trivial: Fix missing double quotes

### DIFF
--- a/nested-passthrough/scripts/edpm-deploy-rhel-ai.sh
+++ b/nested-passthrough/scripts/edpm-deploy-rhel-ai.sh
@@ -101,7 +101,7 @@ openstack server list --long
 echo "Pinging $FIP_ADDR for 120 seconds until it responds"
 timeout 120 bash -c "while true; do if ping -c1 -i1 $FIP_ADDR &>/dev/null; then echo 'Machine is up and running up'; break; fi; done"
 
-echo "Changing the default DNS nameserver in the instance to 192.168.122.80
+echo "Changing the default DNS nameserver in the instance to 192.168.122.80"
 ssh -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ./${VM_NAME}.pem cloud-user@${FIP_ADDR} 'echo "nameserver 192.168.122.80" | sudo tee /etc/resolv.conf'
 
 if [[ -e ~/pull-secret ]]; then


### PR DESCRIPTION
There's missing double quotes in the scripts/edpm-deploy-rhel-ai.sh script which causes the following error:

/tmp/edpm-deploy-rhel-ai.sh: line 112: unexpected EOF while looking for matching `"' command terminated with exit code 2
make: *** [Makefile:136: deploy_rhel_ai] Error 2