### PR TITLE
NO-JIRA: Decrease default AI_DISK size

### DIFF
--- a/nested-passthrough/Makefile
+++ b/nested-passthrough/Makefile
@@ -7,7 +7,7 @@ AI_NUM_GPUS ?= all
 AI_VM_NAME ?= rhel-ai
 AI_CPUS ?= 20
 AI_RAM ?= 40
-AI_DISK ?= 600
+AI_DISK ?= 500
 
 DEPLOY_CINDER ?= false
 PULL_SECRET ?= ~/pull-secret


### PR DESCRIPTION
**What does this PR do?**
Decrease the default AI_DISK size.

**Why do we need it?**
The RHELAI instances are failing due to a placement problem related to the disk space. The error is the following:
```
2025-09-15 13:19:22.103 17 DEBUG placement.objects.research_context [req-f9a6c03b-243f-4219-946b-f130cb96d3f9 req-e7a56842-f0b8-4916-88c8-a6105bf408bc f8f9bcfa3c90437292a887fa444fe855 a8e0b91f63d540d9b3e7e12c382b95ec - - default default] getting providers with 600 DISK_GB __init__ /usr/lib/python3.9/site-packages/placement/objects/research_context.py:136
2025-09-15 13:19:22.110 17 DEBUG placement.objects.research_context [req-f9a6c03b-243f-4219-946b-f130cb96d3f9 req-e7a56842-f0b8-4916-88c8-a6105bf408bc f8f9bcfa3c90437292a887fa444fe855 a8e0b91f63d540d9b3e7e12c382b95ec - - default default] found no providers with 600 DISK_GB __init__ /usr/lib/python3.9/site-packages/placement/objects/research_context.py:140
```
The same issue was found in [OSPRH-15083](https://issues.redhat.com/browse/OSPRH-15083) at the comment https://issues.redhat.com/browse/OSPRH-15083?focusedId=27820374&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-27820374 

By default, the `EDPM_DISK = 640`, it seems that is not enough space to allocate a RHELAI VM with `AI_DISK = 600`.

After the decrement, the RHELAI instance was successfully deployed. 
```
[mcarpio@unicorn04 ~]$ oc rsh openstackclient openstack server list
+--------------------------------------+---------+--------+---------------------------------------+---------+--------+
| ID                                   | Name    | Status | Networks                              | Image   | Flavor |
+--------------------------------------+---------+--------+---------------------------------------+---------+--------+
| 399d027f-779d-40ce-9aaa-303eed3e6202 | rhel-ai | ACTIVE | private=192.168.0.58, 192.168.122.222 | rhel-ai | nvidia |
+--------------------------------------+---------+--------+---------------------------------------+---------+--------+
[mcarpio@unicorn04 ~]$ oc rsh openstackclient openstack flavor show nvidia -f json | jq -r .disk
500
```
